### PR TITLE
fixing the go get server

### DIFF
--- a/handlers/go_get.go
+++ b/handlers/go_get.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"fmt"
 	"html/template"
+	"io"
 	"log"
 	"net/http"
+	"os"
 )
 
 type goGetTplData struct {
@@ -14,22 +16,30 @@ type goGetTplData struct {
 
 var (
 	goGetHTMLTpl = template.Must(template.New("").Parse(`<html>
-<head><meta name="go-import" content="{{.ImportPrefix}} git {{.RepoRoot}}"/></head>
+<head>
+<meta name="go-import" content="{{.ImportPrefix}} git {{.RepoRoot}}">
+</head>
 <body></body>
 </html>
 `))
 )
 
-func goGet(gitSrvScheme string, gitSrvPort int, srvRoot string) http.Handler {
+func goGet(webPort int, gitScheme string, gitPort int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		importPrefix := r.URL.Path[1:]
+		log.Printf("go-get import prefix = %s", importPrefix)
+		host := r.URL.Host
 		data := goGetTplData{
-			ImportPrefix: importPrefix,
-			RepoRoot:     fmt.Sprintf("%s://%s:%d/%s", gitSrvScheme, srvRoot, gitSrvPort, importPrefix),
+			// ImportPrefix: importPrefix,
+			ImportPrefix: fmt.Sprintf("%s:%d/%s", host, webPort, importPrefix),
+			RepoRoot:     fmt.Sprintf("%s://%s:%d/%s", gitScheme, host, gitPort, importPrefix),
 		}
-		if err := goGetHTMLTpl.Execute(w, data); err != nil {
+		log.Printf("template data = %+v", data)
+		out := io.MultiWriter(w, os.Stdout)
+		if err := goGetHTMLTpl.Execute(out, data); err != nil {
 			log.Printf("Error executing template (%s)", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 	})
 }

--- a/handlers/web.go
+++ b/handlers/web.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 )
 
@@ -16,16 +17,18 @@ type primary struct {
 }
 
 // NewWeb returns the main handler responsible for serving web traffic, including 'go get' traffic
-func NewWeb(srvScheme string, srvPort int, srvRoot string) http.Handler {
-	return primary{goGet: goGet(srvScheme, srvPort, srvRoot), head: head()}
+func NewWeb(webPort int, gitScheme string, gitPort int) http.Handler {
+	return primary{goGet: goGet(webPort, gitScheme, gitPort), head: head()}
 }
 
 func (m primary) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s", r.URL)
 	if r.Method == headMethod {
+		log.Printf(r.Method)
 		m.head.ServeHTTP(w, r)
 		return
-	}
-	if r.URL.Query().Get(goGetQueryKey) == "1" && r.Method == getMethod {
+	} else if r.Method == getMethod && r.URL.Query().Get(goGetQueryKey) == "1" {
+		log.Printf("GET with go-get=1")
 		m.goGet.ServeHTTP(w, r)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ const (
 func buildServeMux(host string, port int) (string, http.Handler) {
 	m := http.NewServeMux()
 	hostStr := fmt.Sprintf("%s:%d", host, port)
-	m.Handle("/", handlers.NewWeb(gitScheme, gitPort, host))
+	m.Handle("/", handlers.NewWeb(servePort, gitScheme, gitPort))
 	return hostStr, m
 }
 


### PR DESCRIPTION
it should return the host, web port and correct import prefix in the first param in the content of the meta tag
